### PR TITLE
add docker env vars for celery node and queues

### DIFF
--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -104,7 +104,6 @@ celery:
   command: celery
   hostname: celery
   environment:
-    - CELERY_APP=yabi.backend.celerytasks
     - CELERY_AUTORELOAD=1
     - DBUSER=yabiapp
     - WAIT_FOR_QUEUE=1

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -59,7 +59,50 @@ celeryprod:
   hostname: celeryprod
   command: celery
   environment:
-    - CELERY_APP=yabi.backend.celerytasks
+    - CELERY_NODE=yabi-node
+    - CELERY_QUEUES=celery
+    - DBUSER=yabiapp
+    - WAIT_FOR_QUEUE=1
+    - WAIT_FOR_DB=1
+    - WAIT_FOR_SSH=1
+    - WAIT_FOR_S3=1
+  volumes_from:
+    - dataprod
+  links:
+    - dbprod:db
+    - mqprod:mq
+    - cacheprod:cache
+    - sshprod:ssh
+    - s3prod:s3
+
+celeryfileprod:
+  image: muccg/yabi:${GIT_TAG}
+  hostname: celeryfileprod
+  command: celery
+  environment:
+    - CELERY_NODE=yabi-node-fsops
+    - CELERY_QUEUES=file_operations
+    - DBUSER=yabiapp
+    - WAIT_FOR_QUEUE=1
+    - WAIT_FOR_DB=1
+    - WAIT_FOR_SSH=1
+    - WAIT_FOR_S3=1
+  volumes_from:
+    - dataprod
+  links:
+    - dbprod:db
+    - mqprod:mq
+    - cacheprod:cache
+    - sshprod:ssh
+    - s3prod:s3
+
+celeryprovprod:
+  image: muccg/yabi:${GIT_TAG}
+  hostname: celeryprovprod
+  command: celery
+  environment:
+    - CELERY_NODE=yabi-node-provisioning
+    - CELERY_QUEUES=provisioning
     - DBUSER=yabiapp
     - WAIT_FOR_QUEUE=1
     - WAIT_FOR_DB=1


### PR DESCRIPTION
Added docker env vars to define celery node and queues. This is with a view to running separate queues in different containers.

The same result could've been achieved by setting the previous var CELERY_OPTS but hopefully this change makes it a little more accessible to see what the config (eg in puppet) is actually doing.

@sztamas 